### PR TITLE
environment: pip install fme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beaker-py
 Bottleneck
 cartopy>=0.22.0
 dask
-fme
+fme==2024.9.0
 fsspec
 gcsfs
 h5netcdf


### PR DESCRIPTION
Install `fme` in the repo environment using pip now that it's published to pypi; verified that the resulting installation can be imported successfully.